### PR TITLE
Edit Heroku deploy button link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ An open-source [Workflowy](http://workflowy.com) clone.
 
 You can use our one-click heroku deploy:
 
-[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/abhshkdz/HackFlowy)
 
 Or proceed manually as follow:
 


### PR DESCRIPTION
I just edited your “Deploy to Heroku” link, but I got the following error:

```
Unable to connect to database: Error: error: no pg_hba.conf entry for host "54.234.65.26", user "sgkxdrjowmfvru", database "d872labj836kgj", SSL off
```

Is it possible to fix this?
